### PR TITLE
[Dialog] Fix alert controller, title and message take half screen eve…

### DIFF
--- a/components/Dialogs/src/MDCAlertController.m
+++ b/components/Dialogs/src/MDCAlertController.m
@@ -422,8 +422,13 @@ static const CGFloat MDCDialogMessageOpacity = 0.54f;
     self.actionsScrollView.frame = actionsScrollViewRect;
   } else {
     // Complex layout case : Split the space between the two scrollviews
-    CGFloat maxActionsHeight = CGRectGetHeight(self.view.bounds) * 0.5f;
-    actionsScrollViewRect.size.height = MIN(maxActionsHeight, actionsScrollViewRect.size.height);
+    if (CGRectGetHeight(contentScrollViewRect) < CGRectGetHeight(self.view.bounds) * 0.5f) {
+      actionsScrollViewRect.size.height = 
+          CGRectGetHeight(self.view.bounds) - contentScrollViewRect.size.height;
+    } else {
+      CGFloat maxActionsHeight = CGRectGetHeight(self.view.bounds) * 0.5f;
+      actionsScrollViewRect.size.height = MIN(maxActionsHeight, actionsScrollViewRect.size.height);
+    }
     actionsScrollViewRect.origin.y =
         CGRectGetHeight(self.view.bounds) - actionsScrollViewRect.size.height;
     self.actionsScrollView.frame = actionsScrollViewRect;


### PR DESCRIPTION
…n they are nil

When actionScrollView's height exceed the container view's height. If the contentScrollView's height is very small or 0, we are leaving a huge white spaces for contentScrollView.

### Thanks for starting a pull request on Material Components!

#### Don't forget:
- [x] Identify the component the PR relates to in brackets in the title. ```[Buttons] Updated documentation```
- [x] Link to GitHub issues it solves. ```closes #1234```
- [x] Sign the CLA bot. You can do this once the pull request is submitted.

[Contributing](./contributing/README.md#pull-requests) has more information and tips for a great
pull request.
